### PR TITLE
fix: correct exist() metrics counter and ensure rejection is always an Error

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -316,20 +316,21 @@ export default class SinkFileSystem extends Sink {
 			}
 
 			fs.stat(pathname, (error, stat) => {
-				this._counter.inc({
-					labels: { success: true, access: true, operation },
-				});
-
 				if (stat && stat.isFile()) {
+					this._counter.inc({
+						labels: { success: true, access: true, operation },
+					});
 					resolve();
 					return;
 				}
+
+				this._counter.inc({ labels: { access: true, operation } });
 
 				if (error) {
 					reject(error);
 					return;
 				}
-				reject();
+				reject(new Error(`File does not exist`));
 			});
 		});
 	}

--- a/test/main.js
+++ b/test/main.js
@@ -597,3 +597,63 @@ test("Sink() - .metrics - all successfull operations", async (t) => {
 	const cleaned = metrics.replace(RE_TIMESTAMP, '"timestamp": -1,');
 	t.assert.snapshot(cleaned);
 });
+
+test("Sink() - .exist() - rejects with an Error instance when path is not a regular file", async () => {
+	// Regression: exist() called reject() with no argument when fs.stat
+	// succeeded but the path was not a regular file (e.g. a directory),
+	// producing undefined as the rejection reason. Callers accessing
+	// error.message would throw a TypeError.
+	const sink = new Sink(DEFAULT_CONFIG);
+
+	// Ensure the sink root exists as a directory to use as the test path.
+	fs.mkdirSync(DEFAULT_CONFIG.sinkFsRootPath, { recursive: true });
+
+	await assert.rejects(
+		// Pass the sink root itself — it exists but is a directory, not a file.
+		sink.exist("/"),
+		(err) => {
+			assert.ok(
+				err instanceof Error,
+				"rejection must be an Error instance, not undefined",
+			);
+			assert.ok(
+				err.message.length > 0,
+				"Error must have a non-empty message",
+			);
+			return true;
+		},
+		"should reject with an Error instance when path is a directory",
+	);
+});
+
+test("Sink() - .exist() - does not record success when file does not exist", async () => {
+	// Regression: the metrics counter was incremented with { success: true }
+	// unconditionally before branching on the stat result, so a missing-file
+	// rejection was counted as a successful access.
+	const sink = new Sink(DEFAULT_CONFIG);
+
+	const metricsInto = new MetricsInto();
+	sink.metrics.pipe(metricsInto);
+
+	// Attempt to check a file that does not exist (should reject).
+	await assert.rejects(sink.exist("/bar/foo/not-exist.json"));
+
+	const metrics = JSON.parse(await metricsInto.done());
+	const existEntry = metrics.find((/** @type {any} */ m) =>
+		m.labels?.some(
+			(/** @type {any} */ l) =>
+				l.name === "operation" && l.value === "exist",
+		),
+	);
+
+	assert.ok(
+		existEntry,
+		"should have a metrics entry for the exist operation",
+	);
+	assert.notEqual(
+		existEntry.labels?.find((/** @type {any} */ l) => l.name === "success")
+			?.value,
+		true,
+		"success label must not be true when the file does not exist",
+	);
+});


### PR DESCRIPTION
## Problem

`exist()` had two bugs in its `fs.stat` callback:

**Metrics always recorded as success**
The counter increment with `{ success: true, access: true }` was placed before the branch that inspects the stat result, so every outcome — including a missing file or a path that is not a regular file — was counted as a successful access. This made the success metric meaningless and hid failed lookups in dashboards.

**Rejection with no argument when path is not a regular file**
When `fs.stat` succeeded but the path was not a regular file (e.g. a directory), `reject()` was called with no argument. Callers receiving `undefined` as the rejection reason and accessing `error.message` or `error.code` would throw a `TypeError`. This is particularly relevant now that `sink.exist()` is called directly by handlers that distinguish "not found" from infrastructure errors.

## Fix

- The `{ success: true }` counter is now only incremented when `stat.isFile()` returns true (the file was found). All other outcomes increment `{ access: true }` without `success`.
- The bare `reject()` call is replaced with `reject(new Error('File does not exist'))` so the rejection is always an `Error` instance with a non-empty message.

## Tests

Two regression tests added:

1. Calls `exist()` with a path that is a directory (causing the `reject()` with no argument to fire) and asserts the rejection is an `Error` instance with a non-empty message.
2. Calls `exist()` with a non-existent file and asserts the metrics entry for the `exist` operation does not have `success: true`.

Both tests fail before this change and pass after.