### PR TITLE
feat: atomic writes via temp-file pattern and write() options

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,6 +1,8 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import crypto from "node:crypto";
+import { Writable } from "node:stream";
 import { ReadFile } from "@eik/common";
 import Sink from "@eik/sink";
 import Metrics from "@metrics/client";
@@ -74,9 +76,10 @@ export default class SinkFileSystem extends Sink {
 	/**
 	 * @param {string} filePath
 	 * @param {string} contentType
+	 * @param {{ ifNotExists?: boolean, ifGenerationMatch?: string | number }} [options]
 	 * @returns {Promise<import('node:stream').Writable>}
 	 */
-	write(filePath, contentType) {
+	write(filePath, contentType, options = {}) {
 		return new Promise((resolve, reject) => {
 			const operation = "write";
 
@@ -99,38 +102,111 @@ export default class SinkFileSystem extends Sink {
 
 			const dir = path.dirname(pathname);
 
-			fs.mkdir(
-				dir,
-				{
-					recursive: true,
-				},
-				(error) => {
-					if (error) {
-						this._counter.inc({
-							labels: { access: true, operation },
+			fs.mkdir(dir, { recursive: true }, (mkdirErr) => {
+				if (mkdirErr) {
+					this._counter.inc({ labels: { access: true, operation } });
+					reject(new Error(`Could not create directory - ${dir}`));
+					return;
+				}
+
+				const tmpPath = path.join(
+					dir,
+					`.${path.basename(pathname)}.tmp.${crypto.randomBytes(4).toString("hex")}`,
+				);
+
+				const fileStream = fs.createWriteStream(tmpPath, {
+					autoClose: true,
+				});
+
+				// Proxy Writable: data flows to tmpPath; on clean finish the temp
+				// file is moved to the final path atomically. On destroy (aborted
+				// upload) the temp file is removed so no partial file accumulates.
+				const counter = this._counter;
+				const ifNotExists = options.ifNotExists;
+
+				const proxy = new Writable({
+					write(chunk, encoding, cb) {
+						if (!fileStream.write(chunk, encoding)) {
+							fileStream.once("drain", cb);
+						} else {
+							cb();
+						}
+					},
+
+					final(cb) {
+						fileStream.end(() => {
+							if (ifNotExists) {
+								// fs.link is atomic: fails with EEXIST if target exists.
+								fs.link(tmpPath, pathname, (linkErr) => {
+									fs.unlink(tmpPath, () => {});
+									if (linkErr) {
+										if (linkErr.code === "EEXIST") {
+											const err = new Error(
+												`File already exists: ${filePath}`,
+											);
+											// @ts-ignore
+											err.code = "ALREADY_EXISTS";
+											counter.inc({
+												labels: {
+													access: true,
+													operation,
+												},
+											});
+											cb(err);
+										} else {
+											counter.inc({
+												labels: {
+													access: true,
+													operation,
+												},
+											});
+											cb(linkErr);
+										}
+									} else {
+										counter.inc({
+											labels: {
+												success: true,
+												access: true,
+												operation,
+											},
+										});
+										cb();
+									}
+								});
+							} else {
+								fs.rename(tmpPath, pathname, (renameErr) => {
+									if (renameErr) {
+										fs.unlink(tmpPath, () => {});
+										counter.inc({
+											labels: { access: true, operation },
+										});
+										cb(renameErr);
+									} else {
+										counter.inc({
+											labels: {
+												success: true,
+												access: true,
+												operation,
+											},
+										});
+										cb();
+									}
+								});
+							}
 						});
-						reject(
-							new Error(`Could not create directory - ${dir}`),
-						);
-						return;
-					}
+					},
 
-					const stream = fs.createWriteStream(pathname, {
-						autoClose: true,
-						emitClose: true,
-					});
+					destroy(err, cb) {
+						// Aborted upload — clean up the temp file.
+						fileStream.destroy();
+						fs.unlink(tmpPath, () => cb(err));
+					},
+				});
 
-					this._counter.inc({
-						labels: {
-							success: true,
-							access: true,
-							operation,
-						},
-					});
+				fileStream.on("error", (err) => proxy.destroy(err));
 
-					resolve(stream);
-				},
-			);
+				resolve(proxy);
+			});
 		});
 	}
 

--- a/test/main.js
+++ b/test/main.js
@@ -657,3 +657,85 @@ test("Sink() - .exist() - does not record success when file does not exist", asy
 		"success label must not be true when the file does not exist",
 	);
 });
+
+// Regression tests for write() options and partial file cleanup (#10)
+
+test("Sink() - .write() - destroyed stream does not leave a partial file (#10)", async () => {
+	// Regression (#10): fs.createWriteStream() created and truncated the
+	// target file on open. Destroying the stream mid-write left an empty
+	// file at the target path. With the temp-file + rename pattern the
+	// final path is only created on a clean finish.
+	const sink = new Sink(DEFAULT_CONFIG);
+	const dir = slug();
+	const file = `${dir}/partial.txt`;
+
+	const stream = await sink.write(file, "text/plain");
+	// Destroy without writing anything — simulates an aborted upload.
+	stream.destroy();
+
+	// Give the async cleanup a tick to run.
+	await new Promise((resolve) => setImmediate(resolve));
+
+	await assert.rejects(
+		sink.exist(file),
+		"destroyed write must not leave a partial file at the target path",
+	);
+
+	// Clean up directory if it was created.
+	try {
+		await sink.delete(dir);
+	} catch {
+		/* do nothing */
+	}
+});
+
+test("Sink() - .write() - ifNotExists rejects when file already exists", async () => {
+	const sink = new Sink(DEFAULT_CONFIG);
+	const dir = slug();
+	const file = `${dir}/once.txt`;
+
+	const w1 = await sink.write(file, "text/plain");
+	await pipe(readFileStream("../fixtures/import-map.json"), w1);
+
+	await assert.rejects(
+		async () => {
+			const w2 = await sink.write(file, "text/plain", {
+				ifNotExists: true,
+			});
+			await pipe(readFileStream("../fixtures/import-map.json"), w2);
+		},
+		(err) => {
+			assert.strictEqual(
+				/** @type {any} */ (err).code,
+				"ALREADY_EXISTS",
+				"should reject with ALREADY_EXISTS when file already exists",
+			);
+			return true;
+		},
+	);
+
+	try {
+		await sink.delete(dir);
+	} catch {
+		/* do nothing */
+	}
+});
+
+test("Sink() - .write() - ifNotExists succeeds when file does not exist", async () => {
+	const sink = new Sink(DEFAULT_CONFIG);
+	const dir = slug();
+	const file = `${dir}/new.txt`;
+
+	const w = await sink.write(file, "text/plain", { ifNotExists: true });
+	await assert.doesNotReject(
+		pipe(readFileStream("../fixtures/import-map.json"), w),
+		"ifNotExists should succeed when file does not yet exist",
+	);
+	await assert.doesNotReject(sink.exist(file));
+
+	try {
+		await sink.delete(dir);
+	} catch {
+		/* do nothing */
+	}
+});


### PR DESCRIPTION
## Summary

**Partial file cleanup:** \`write()\` now writes to a uniquely-named temp file in the same directory and renames it to the final path only on a clean pipeline finish. If the stream is destroyed (aborted upload) or the pipeline errors, the temp file is unlinked. No partial or empty file accumulates at the target path.

**Atomic create-if-absent:** \`write(path, contentType, { ifNotExists: true })\` uses \`fs.link()\` to move the temp file to the final path. \`link()\` fails atomically with \`EEXIST\` if the target already exists, causing the write to reject with \`code: ALREADY_EXISTS\`.

An optional \`ifGenerationMatch\` value is accepted in the signature for interface compatibility with sink-gcs; the filesystem sink does not perform generation tracking.

Existing callers without options continue to work unchanged.